### PR TITLE
Fix error related to TS version when installing via NPM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "react-dom": "18.2.0",
         "react-query": "3.39.3",
         "react-scripts": "5.0.1",
-        "styled-components": "6.1.8",
-        "typescript": "5.6.3"
+        "styled-components": "6.1.8"
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "7.21.11",
@@ -30,7 +29,8 @@
         "@types/react": "18.2.48",
         "@types/react-dom": "18.2.18",
         "jest": "27.5.1",
-        "miragejs": "0.1.48"
+        "miragejs": "0.1.48",
+        "typescript": "5.6.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "react-dom": "18.2.0",
     "react-query": "3.39.3",
     "react-scripts": "5.0.1",
-    "styled-components": "6.1.8",
-    "typescript": "5.6.3"
+    "styled-components": "6.1.8"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -49,6 +48,10 @@
     "@types/react": "18.2.48",
     "@types/react-dom": "18.2.18",
     "jest": "27.5.1",
-    "miragejs": "0.1.48"
+    "miragejs": "0.1.48",
+    "typescript": "5.6.3"
+  },
+  "overrides": {
+    "typescript": "5.6.3"
   }
 }


### PR DESCRIPTION
`react-scripts` doesn't support TS > 4, so `npm i` throws an error:
![Screenshot 2024-11-11 at 3 10 19 PM](https://github.com/user-attachments/assets/8967693d-7f9f-4cb1-bfbd-3929b5b32f3f)

We need to force an override for it to work, since there's no newer version of react-scripts to upgrade to:
![Screenshot 2024-11-11 at 3 08 38 PM](https://github.com/user-attachments/assets/9d10e7da-1004-4b75-a9e3-22c808ab806c)
